### PR TITLE
Make external message id unique

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -14,5 +14,5 @@ jobs:
         uses: deepakputhraya/action-branch-name@master
         with:
           regex: '([a-z])+\/([a-z])+'
-          allowed_prefixes: 'feature,fix'
+          allowed_prefixes: 'feature,bugfix'
           min_length: 6

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,10 @@ For users, who only need to work with the data captured by bots, there's now a `
 
 ## What's Changed
 
+### Fix for an issue when Telegram Message Id was not unique
+
+Due to the format the telegram message ids are generated there was a possibility of the duplicated external id. That should be the case anymore.
+
 ### Support sending different message types
 
 It used to be possible to send the text messages only. Now, these message types are supported:

--- a/src/main/default/classes/BotUtils.cls
+++ b/src/main/default/classes/BotUtils.cls
@@ -20,7 +20,12 @@ public class BotUtils {
         if (sourceExternalId.contains(':')) {
             return sourceExternalId;
         }
-        return (sourceExternalId + ':').rightPad(EXTERNAL_ID_LENGTH, salt);
+        String sourceSaltValue = salt.substringBefore(':');
+        String concatenatedExternalId = sourceExternalId + ':' + sourceSaltValue;
+        if (concatenatedExternalId.length() <= EXTERNAL_ID_LENGTH) {
+            return concatenatedExternalId;
+        }
+        return (sourceExternalId + ':').rightPad(EXTERNAL_ID_LENGTH, sourceSaltValue);
     }
 
     public static Object createInstance(String typeName) {

--- a/src/main/default/classes/BotUtils.cls
+++ b/src/main/default/classes/BotUtils.cls
@@ -16,11 +16,11 @@ public class BotUtils {
         return Pattern.matches(URL_REGEX, text);
     }
 
-    public static String generateExternalId(String botTokenHash, String sourceExternalId) {
+    public static String generateExternalId(String sourceExternalId, String salt) {
         if (sourceExternalId.contains(':')) {
             return sourceExternalId;
         }
-        return (sourceExternalId + ':').rightPad(EXTERNAL_ID_LENGTH, botTokenHash);
+        return (sourceExternalId + ':').rightPad(EXTERNAL_ID_LENGTH, salt);
     }
 
     public static Object createInstance(String typeName) {

--- a/src/main/default/classes/services/BotService.cls
+++ b/src/main/default/classes/services/BotService.cls
@@ -35,7 +35,7 @@ global abstract class BotService implements IBotService {
                 Parameters__c = parameters.toJson(true),
                 Chat__r = new Chat__c(ExternalId__c = BotUtils.generateExternalId(chatId, bot.tokenHash)),
                 Bot__c = bot.id,
-                ExternalId__c = BotUtils.generateExternalId(params.getString('messageId'), chatId.substringBefore(':'))
+                ExternalId__c = BotUtils.generateExternalId(params.getString('messageId'), chatId)
             );
             BotUtils.saveAsync(new List<SObject> { messageRecord }, 'ExternalId__c');
         }

--- a/src/main/default/classes/services/BotService.cls
+++ b/src/main/default/classes/services/BotService.cls
@@ -33,9 +33,9 @@ global abstract class BotService implements IBotService {
                 Text__c = params.getString('text'),
                 MediaUrl__c = params.getString('mediaUrl'),
                 Parameters__c = parameters.toJson(true),
-                Chat__r = new Chat__c(ExternalId__c = BotUtils.generateExternalId(bot.tokenHash, chatId)),
+                Chat__r = new Chat__c(ExternalId__c = BotUtils.generateExternalId(chatId, bot.tokenHash)),
                 Bot__c = bot.id,
-                ExternalId__c = params.getString('messageId')
+                ExternalId__c = BotUtils.generateExternalId(params.getString('messageId'), chatId.substringBefore(':'))
             );
             BotUtils.saveAsync(new List<SObject> { messageRecord }, 'ExternalId__c');
         }

--- a/src/main/default/classes/trigger-handlers/BotUpdateHandler.cls
+++ b/src/main/default/classes/trigger-handlers/BotUpdateHandler.cls
@@ -75,7 +75,7 @@ public class BotUpdateHandler implements Triggers.IHandler {
         return new Chat__c(
             Name = chat.title,
             Bot__c = bot.id,
-            ExternalId__c = BotUtils.generateExternalId(bot.tokenHash, chat.id)
+            ExternalId__c = BotUtils.generateExternalId(chat.id, bot.tokenHash)
         );
     }
 
@@ -99,7 +99,7 @@ public class BotUpdateHandler implements Triggers.IHandler {
             User__r = new ChatUser__c(ExternalId__c = userId),
             Text__c = message.text,
             SendDate__c = message.sentAt,
-            ExternalId__c = message.id
+            ExternalId__c = BotUtils.generateExternalId(message.id, chatId.substringBefore(':'))
         );
     }
 

--- a/src/main/default/classes/trigger-handlers/BotUpdateHandler.cls
+++ b/src/main/default/classes/trigger-handlers/BotUpdateHandler.cls
@@ -99,7 +99,7 @@ public class BotUpdateHandler implements Triggers.IHandler {
             User__r = new ChatUser__c(ExternalId__c = userId),
             Text__c = message.text,
             SendDate__c = message.sentAt,
-            ExternalId__c = BotUtils.generateExternalId(message.id, chatId.substringBefore(':'))
+            ExternalId__c = BotUtils.generateExternalId(message.id, chatId)
         );
     }
 

--- a/src/test/classes/BotUpdateEventTriggerTest.cls
+++ b/src/test/classes/BotUpdateEventTriggerTest.cls
@@ -43,7 +43,7 @@ private class BotUpdateEventTriggerTest {
         System.assertEquals(users.get(0).Id, messages.get(0).User__c);
         System.assertEquals(chats.get(0).Id, messages.get(0).Chat__c);
         System.assertEquals(null, messages.get(0).Bot__c);
-        System.assertEquals('223123123', messages.get(0).ExternalId__c);
+        System.assertEquals('223123123:876541222', messages.get(0).ExternalId__c);
         System.assertEquals(Date.newInstance(2022, 1, 1), messages.get(0).SendDate__c.date());
 
         List<BotContext> contexts = BotHandlerMock.executedContexts;
@@ -143,7 +143,7 @@ private class BotUpdateEventTriggerTest {
         System.assertEquals(users.get(0).Id, messages.get(0).User__c);
         System.assertEquals(chats.get(0).Id, messages.get(0).Chat__c);
         System.assertEquals(null, messages.get(0).Bot__c);
-        System.assertEquals('4912661846655238145', messages.get(0).ExternalId__c);
+        System.assertEquals('4912661846655238145:01234567890A=', messages.get(0).ExternalId__c);
         System.assertEquals(Date.newInstance(2022, 1, 1), messages.get(0).SendDate__c.date());
 
         List<BotContext> contexts = BotHandlerMock.executedContexts;


### PR DESCRIPTION
### What does this PR do?

This PR provides a fix for the issue with Telegram bots where external message ids are not unique across all chats. This is fixed by concatenating the chat id to the message external id.

## The PR fulfills these requirements:

- [x] Tests for the proposed changes have been added/updated.  
- [x] The documentation has been updated according to the introduced/changed components.  
- [x] ApexDoc comments have been attached to all `global` classes, fields, properties and methods.
