### PR TITLE
Allow updating bot webhook events

### DIFF
--- a/src/main/default/classes/trigger-handlers/BotWebhookHandler.cls
+++ b/src/main/default/classes/trigger-handlers/BotWebhookHandler.cls
@@ -11,9 +11,9 @@ public class BotWebhookHandler implements Triggers.IHandler {
     }
 
     public void handle(Triggers.Context context) {
-        for (BotModel bot : getBots(context.props)) {
+        for (BotModel bot : filterBots(context.props)) {
             BotWebhookService service = serviceFactory.createWebhookService(bot);
-            if (context.props.isInsert || context.props.isUndelete) {
+            if (context.props.isInsert || context.props.isUndelete || context.props.isUpdate) {
                 service.setWebhook();
             }
             if (context.props.isDelete) {
@@ -22,11 +22,23 @@ public class BotWebhookHandler implements Triggers.IHandler {
         }
     }
 
-    private List<BotModel> getBots(Triggers.Props props) {
+    private List<BotModel> filterBots(Triggers.Props props) {
         List<BotModel> bots = new List<BotModel>();
         for (Bot__c bot : (List<Bot__c>) (props.isDelete ? props.oldList : props.newList)) {
-            bots.add(new BotModel(bot));
+            Bot__c oldBot = (Bot__c) props.oldMap?.get(bot.Id);
+            if (
+                props.isInsert ||
+                props.isDelete ||
+                props.isUndelete ||
+                (props.isUpdate && areWebhookEventsChanged(bot, oldBot))
+            ) {
+                bots.add(new BotModel(bot));
+            }
         }
         return bots;
+    }
+
+    private Boolean areWebhookEventsChanged(Bot__c bot, Bot__c oldBot) {
+        return bot.WebhookEvents__c != oldBot?.WebhookEvents__c;
     }
 }

--- a/src/main/default/objects/Bot__c/validationRules/RestrictFieldsUpdate.validationRule-meta.xml
+++ b/src/main/default/objects/Bot__c/validationRules/RestrictFieldsUpdate.validationRule-meta.xml
@@ -2,13 +2,12 @@
 <ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RestrictFieldsUpdate</fullName>
     <active>true</active>
-    <description>Prevents the user from updating such fields as Token, Type and Webhook Events</description>
+    <description>Prevents the user from updating such fields as Token and Type</description>
     <errorConditionFormula>NOT(ISNEW())
 &amp;&amp; (
   ISCHANGED(Token__c)
   || ISCHANGED(TokenHash__c)
   || ISCHANGED(Type__c)
-  || ISCHANGED(WebhookEvents__c)
 )</errorConditionFormula>
-    <errorMessage>It&apos;s forbidden to update such fields as Token, Type and Webhook Events. Delete and create a new Bot record instead</errorMessage>
+    <errorMessage>It&apos;s forbidden to update such fields as Token and Type. Delete and create a new Bot record instead</errorMessage>
 </ValidationRule>

--- a/src/main/default/triggers/BotTrigger.trigger
+++ b/src/main/default/triggers/BotTrigger.trigger
@@ -1,9 +1,10 @@
-trigger BotTrigger on Bot__c(before insert, after insert, before update, after update, after delete, after undelete) {
+trigger BotTrigger on Bot__c(before insert, after insert, after update, after delete, after undelete) {
     Triggers.IHandler webHookHandler = new BotWebhookHandler();
     Triggers.dispatcher
         .bind(TriggerOperation.BEFORE_INSERT, new BotPopulateTokenHashHandler())
         .bind(TriggerOperation.BEFORE_INSERT, new BotValidateHandlerTypeHandler())
         .bindAsync(TriggerOperation.AFTER_INSERT, webHookHandler)
+        .bindAsync(TriggerOperation.AFTER_UPDATE, webHookHandler)
         .bindAsync(TriggerOperation.AFTER_DELETE, webHookHandler)
         .bindAsync(TriggerOperation.AFTER_UNDELETE, webHookHandler)
         .run(new BotErrorHandler());

--- a/src/test/classes/BotTriggerTest.cls
+++ b/src/test/classes/BotTriggerTest.cls
@@ -18,7 +18,6 @@ private class BotTriggerTest {
         List<Bot__c> newBots = [
             SELECT Type__c, WebhookEvents__c, Handler__c, Token__c, TokenHash__c
             FROM Bot__c
-            LIMIT 1
         ];
         Assert.areEqual(1, newBots.size());
         Assert.isTrue(String.isNotBlank(newBots.get(0).TokenHash__c));
@@ -65,6 +64,34 @@ private class BotTriggerTest {
     }
 
     @IsTest
+    private static void update_telegramWithNewWebhookEvents_shouldUpdateBotAndSetWebhook() {
+        Test.setMock(HttpCalloutMock.class, new TelegramBotCalloutMock());
+
+        Test.startTest();
+        insert createBot(BotType.Telegram, BOT_HANDLER);
+        Test.stopTest();
+
+        Bot__c bot = [
+            SELECT Type__c, WebhookEvents__c, Handler__c, Token__c, TokenHash__c
+            FROM Bot__c
+            LIMIT 1
+        ];
+        bot.WebhookEvents__c =
+            TelegramUpdateEventType.Message.name() +
+            ';' +
+            TelegramUpdateEventType.EditedMessage.name();
+        update bot;
+
+        Bot__c updatedBot = [
+            SELECT Type__c, WebhookEvents__c, Handler__c, Token__c, TokenHash__c
+            FROM Bot__c
+            LIMIT 1
+        ];
+
+        Assert.areEqual('edited_message;message', updatedBot.WebhookEvents__c);
+    }
+
+    @IsTest
     private static void delete_telegramWithCorrectData_shouldDeleteAndUnsetWebhook() {
         Test.setMock(HttpCalloutMock.class, new TelegramBotCalloutMock());
 
@@ -91,7 +118,6 @@ private class BotTriggerTest {
         List<Bot__c> newBots = [
             SELECT Type__c, WebhookEvents__c, Handler__c, Token__c, TokenHash__c
             FROM Bot__c
-            LIMIT 1
         ];
         Assert.areEqual(1, newBots.size());
         Assert.isTrue(String.isNotBlank(newBots.get(0).TokenHash__c));

--- a/src/test/classes/BotTriggerTest.cls
+++ b/src/test/classes/BotTriggerTest.cls
@@ -88,7 +88,10 @@ private class BotTriggerTest {
             LIMIT 1
         ];
 
-        Assert.areEqual('edited_message;message', updatedBot.WebhookEvents__c);
+        List<String> webhookEvents = updatedBot.WebhookEvents__c.split(';');
+        Assert.areEqual(2, webhookEvents.size());
+        Assert.isTrue(webhookEvents.contains('message'));
+        Assert.isTrue(webhookEvents.contains('edited_message'));
     }
 
     @IsTest


### PR DESCRIPTION
### What does this PR do?

This PR introduces a feature, allowing to update a bot webhook event, which resets bot webhooks

## The PR fulfills these requirements:

- [x] Tests for the proposed changes have been added/updated.  
- [ ] The documentation has been updated according to the introduced/changed components.  
- [x] ApexDoc comments have been attached to all `global` classes, fields, properties, and methods.
